### PR TITLE
Adding " and " around databaseUrl value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Modify `config.js` with your MongoDB connection string. If you have MongoDB runn
 
 ```
 mongo: {
-  databaseUrl: mongodb://localhost:27017/skynet
+  databaseUrl: "mongodb://localhost:27017/skynet"
 },
 ```
 


### PR DESCRIPTION
Will NOT work -- databaseUrl: mongodb://localhost:27017/skynet

Yields "Unexpected token :" error when trying to run the server.js.
Adding double-apostrophes around the value makes it parse-able.

Working version -- databaseUrl: "mongodb://localhost:27017/skynet"